### PR TITLE
Fix: Correctly pass auth token to Stripe checkout session

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -2,13 +2,18 @@ import { loadStripe } from '@stripe/stripe-js';
 import { STRIPE_CONFIG } from '../config/stripe';
 import { getApiUrl } from '../utils/api';
 
-export const createCheckoutSession = async (priceId: string, userId: string, userEmail: string) => {
+export const createCheckoutSession = async (
+  priceId: string,
+  userId: string,
+  userEmail: string,
+  accessToken: string | null // Added parameter
+) => {
   try {
     console.log('Creating checkout session with:', { priceId, userId, userEmail });
-    
-    const token = localStorage.getItem('sb-access-token');
-    if (!token) {
-      throw new Error('User not authenticated');
+
+    if (!accessToken) {
+      console.error('Access token is missing in createCheckoutSession');
+      throw new Error('User not authenticated. Missing access token.');
     }
     
     // First, create a checkout session on the server
@@ -16,21 +21,21 @@ export const createCheckoutSession = async (priceId: string, userId: string, use
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
+        'Authorization': `Bearer ${accessToken}`, // Use the passed accessToken
       },
       body: JSON.stringify({
         priceId,
         userId,
         userEmail,
-        successUrl: `${window.location.origin}/payment/success?plan=basic`,
+        successUrl: `${window.location.origin}/payment/success?plan=basic`, // Consider making plan dynamic if needed
         cancelUrl: `${window.location.origin}/payment/cancel`,
       }),
     });
 
     if (!response.ok) {
       const errorData = await response.json();
-      console.error('Error creating checkout session:', errorData);
-      throw new Error(errorData.error || 'Failed to create checkout session');
+      console.error('Error creating checkout session on server:', errorData); // Clarified log
+      throw new Error(errorData.error || 'Failed to create checkout session on server'); // Clarified error
     }
 
     const { sessionId } = await response.json();
@@ -51,10 +56,23 @@ export const createCheckoutSession = async (priceId: string, userId: string, use
 
     if (error) {
       console.error('Stripe checkout error:', error);
-      throw error;
+      throw error; // Re-throw Stripe's error object
     }
-  } catch (error) {
-    console.error('Error creating checkout session:', error);
+  } catch (error) { // Catch block for the entire function
+    // Log the error if it's not already a detailed one from above
+    if (!(error instanceof Error && error.message.includes('Failed to create checkout session on server')) && 
+        !(error instanceof Error && error.message.includes('User not authenticated. Missing access token.')) &&
+        !(error instanceof Error && error.message.includes('Stripe failed to load')) &&
+        !(error.name === 'StripeCheckoutError') // Assuming Stripe error object has a name
+    ) {
+      // Added a check to see if error is an instance of Error before accessing error.name
+      if (error instanceof Error && error.name === 'StripeCheckoutError') {
+        // Already logged by Stripe checkout error
+      } else {
+        console.error('Unhandled error in createCheckoutSession:', error);
+      }
+    }
+    // Re-throw the original error to be handled by the caller
     throw error;
   }
 };


### PR DESCRIPTION
This commit resolves a "User not authenticated" error that occurred during the Stripe checkout session creation. The issue was caused by an incorrect method of retrieving the Supabase access token in the client-side Stripe service.

Key changes:

1.  **Modified `src/services/stripe.ts`:**
    *   The `createCheckoutSession` function now accepts the Supabase `accessToken` as a parameter instead of attempting to read it from `localStorage` with a hardcoded key.
    *   This ensures that the valid, current access token is used when calling the backend to create the Stripe session.

2.  **Updated `src/App.tsx`:**
    *   The `handleSubscribe` function, which initiates the subscription process, now retrieves the `session.access_token` from `UserContext`.
    *   This token is then correctly passed to the `createCheckoutSession` function.
    *   Error handling in `handleSubscribe` has also been slightly enhanced to provide clearer feedback for authentication-related issues during subscription.

These changes ensure that your authentication state is accurately conveyed to the Stripe session creation endpoint, fixing the reported bug and allowing authenticated users to proceed to checkout.