### PR TITLE
Fix: Clear previous reading result when selecting a new reading type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,15 @@ const App: React.FC = () => {
     }
   }, [isDarkMode]);
 
+  // Effect to clear readingResult when selectedReadingType changes
+  useEffect(() => {
+    // This effect runs whenever selectedReadingType changes.
+    // When a new reading type is selected (or selection is cleared),
+    // we should clear any previous reading result to ensure the form is shown.
+    console.log('Selected reading type changed, clearing previous result.'); // Optional: for debugging
+    setReadingResult(null);
+  }, [selectedReadingType]); // Dependency: selectedReadingType
+
   // Sync anonymous readings when user signs in
   useEffect(() => {
     if (user && localStorage.getItem('freeReadingsUsed')) {


### PR DESCRIPTION
This commit resolves an issue where the result of a previous reading would remain displayed when you navigated to a different reading type. The expected behavior is for the input form of the newly selected reading type to be shown.

The fix involves adding a `useEffect` hook in `App.tsx`. This hook monitors changes to the `selectedReadingType` state. When `selectedReadingType` is updated (indicating you have chosen a new reading type or navigated to a different reading type's page), the `useEffect` hook now clears the `readingResult` state by setting it to `null`.

This ensures that the UI correctly displays the `ReadingForm` for your current selection rather than stale output from a previous interaction.